### PR TITLE
destination filename defaults to source filename

### DIFF
--- a/luatool/luatool.py
+++ b/luatool/luatool.py
@@ -137,7 +137,9 @@ if __name__ == '__main__':
 
     # compile?
     if args.compile:
+       if args.verbose: sys.stderr.write("\r\nStage 5. Compiling")
        writeln("node.compile(\""+args.dest+"\")\r")
+       writeln("file.remove(\""+args.dest+"\")\r")
 
     # restart or dofile
     if args.restart:


### PR DESCRIPTION
Strip the path to source file and just uses the filename for destination. This is not backward compatible as currently you can load different files under the name **main.lua** by just using the -f option, but I feel this is more useful.