### PR TITLE
Explicitly require Python 2

### DIFF
--- a/luatool/luatool.py
+++ b/luatool/luatool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # ESP8266 luatool
 # Author e-mail: 4ref0nt@gmail.com


### PR DESCRIPTION
This is required on OSes that default to python3, e.g. Arch Linux, to run this correctly without having to explicitly specify python2 like this:
```
python2 luatool.py
```