### PR TITLE
Add support to connect to a module via TCP & telnet server

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,25 @@ If you want load and autoexecute file main.lua, command dofile("main.lua"), you 
 ./luatool.py --dofile
 ```
 Typically, place wifi.setmode, wifi.sta.config commands to init.lua file for connecting to you AP with low risk of boot loop, and other code place to main.lua for manually start and debug.
+
+####Alternative use:
+
+This requires a nodemcu based module already configured to meet the following conditions:
+
+- the module is accessible via TCP/IP 
+- the telnet server (file: **telnet_srv.lua**) is running 
+
+Now the option **--ip IP[:PORT]** enables you to specify an IP and optionally a port (if changed for the telnet server)
+that will be used to communicate with the module via TCP/IP.
+
+####Examples:
+
+```
+./luatool.py --ip 192.168.12.34 --src file.lua --dest test.lua --dofile 
+```
+
+- --ip - the IP to connect to. Note that no Port is given, so 23 will be used (can be changed in **telnet_srv.lua**)
+- --src - source disk file, default main.lua
+- --dest - destination flash file, default main.lua
+- --dofile - run the just uploaded file
+

--- a/luatool/telnet_srv.lua
+++ b/luatool/telnet_srv.lua
@@ -5,8 +5,11 @@ function setupTelnetServer()
     inUse = false
     function listenFun(sock)
         if inUse then
+            sock:send("Already in use.\n")
+            sock:close()
             return
         end
+        inUse = true
 
         function s_output(str)
             if(sock ~=nil) then
@@ -22,6 +25,7 @@ function setupTelnetServer()
 
         sock:on("disconnection",function(sock)
                 node.output(nil)
+                inUse = false
             end)
 
         sock:send("Welcome to NodeMCU world.\n> ")

--- a/luatool/telnet_srv.lua
+++ b/luatool/telnet_srv.lua
@@ -1,0 +1,32 @@
+--
+-- setup a telnet server that hooks the sockets input
+--
+function setupTelnetServer()
+    inUse = false
+    function listenFun(sock)
+        if inUse then
+            return
+        end
+
+        function s_output(str)
+            if(sock ~=nil) then
+                sock:send(str)
+            end
+        end
+
+        node.output(s_output, 0)
+
+        sock:on("receive",function(sock, input)
+                node.input(input)
+            end)
+
+        sock:on("disconnection",function(sock)
+                node.output(nil)
+            end)
+
+        sock:send("Welcome to NodeMCU world.\n> ")
+    end
+
+    telnetServer = net.createServer(net.TCP, 180)
+    telnetServer:listen(23, listenFun)
+end


### PR DESCRIPTION
Add a lua telnet server that can be run on the nodemcu device. The luatool.py was extended to offer exchangeable transports (serial and tcp) to support all features also via remote telnet sessions.